### PR TITLE
Add error message for wrong email/password

### DIFF
--- a/pygoodwe/__init__.py
+++ b/pygoodwe/__init__.py
@@ -245,6 +245,10 @@ class API():
                 timeout=timeout,
             )
             response.raise_for_status()
+            data = response.json()
+            if data.get("code") != 0:
+                logging.error("Failed to log in: %s", data.get("msg"))
+                return False
         except requests.exceptions.RequestException as exp:
             logging.error("RequestException during do_login(): %s", exp)
             return False


### PR DESCRIPTION
When the log in fails because of an invalid email or password, the API returns a HTTP 200 response with the following JSON content (tested with the example config):
```json
{
  "hasError": false,
  "code": 100005,
  "msg": "Email or password error.",
  "data": null,
  "components": {
    "para": null,
    "langVer": 179,
    "timeSpan": 0,
    "api": "http://semsportal.com:85/api/v2/Common/CrossLogin",
    "msgSocketAdr": "https://eu-xxzx.semsportal.com"
  }
}
```

Currently, this error is ignored by pygoodwe.

This pull request adds a check for this response (to be more specific, it checks for a non-zero `code` value, since even `hasError` is `false` in this error response ...) and logs an appropriate error message:
```
ERROR:root:Failed to log in: Email or password error.
```