### PR TITLE
feat: add getPowerStationPowerReportByMonth for monthly power reports

### DIFF
--- a/example_monthly_report_jsonl.py
+++ b/example_monthly_report_jsonl.py
@@ -1,0 +1,36 @@
+"""Dump the last six months of power reports as JSONL."""
+
+import json
+import sys
+from datetime import date, timedelta
+
+try:
+    from config import args
+except ImportError:
+    print("Create a config.py with args dict containing gw_station_id, gw_account, gw_password", file=sys.stderr)
+    sys.exit(1)
+
+from pygoodwe import SingleInverter
+
+def main() -> None:
+    station_id = args["gw_station_id"]
+    account = args["gw_account"]
+    password = args["gw_password"]
+
+    inv = SingleInverter(station_id, account, password, skipload=True)
+    if not inv.do_login():
+        print("Login failed", file=sys.stderr)
+        sys.exit(1)
+
+    today = date.today()
+    for i in range(6, 0, -1):
+        day = today - timedelta(days=i * 30)
+        month_str = day.strftime("%Y-%m")
+        result = inv.getPowerStationPowerReportByMonth(day)
+        if result is None:
+            print(f"No data for {month_str}", file=sys.stderr)
+            continue
+        print(json.dumps({"month": month_str, "data": result}, default=str))
+
+if __name__ == "__main__":
+    main()

--- a/pygoodwe/__init__.py
+++ b/pygoodwe/__init__.py
@@ -220,6 +220,27 @@ class API:
             return False
         return True
 
+    def getPowerStationPowerReportByMonth(
+        self,
+        report_date: date,
+        page_index: int = 1,
+        page_size: int = 8,
+    ) -> Optional[Dict[str, Any]]:
+        """retrieves the monthly power report for the given date
+
+        Returns a dict with keys like 'record', 'list' (per-station data
+        including month_power, avg_day_power, total_power), or None on failure.
+        """
+        month_str = report_date.strftime("%Y-%m")
+        payload = {
+            "date": month_str,
+            "pw_id": self.system_id,
+            "page_index": page_index,
+            "page_size": page_size,
+            "is_report": 1,
+        }
+        return self.call("v1/ReportData/GetPowerStationPowerReportByMonth", payload)
+
     def do_login(self, timeout: int = 10) -> bool:
         """does the login and token saving thing"""
         login_payload = {

--- a/tests/test_mocked.py
+++ b/tests/test_mocked.py
@@ -277,4 +277,5 @@ def test_get_power_station_power_report_by_month_success(
         )
         result = goodwe.getPowerStationPowerReportByMonth(date(2024, 1, 1))
         assert result == report_data
+        assert result is not None
         assert result["list"][0]["month_power"] == 688.0

--- a/tests/test_mocked.py
+++ b/tests/test_mocked.py
@@ -245,3 +245,36 @@ def test_get_day_detailed_readings_excel_success(
         target = tmp_path / "output.xls"
         assert goodwe.getDayDetailedReadingsExcel(date(2024, 1, 2), filename=str(target))
         assert target.read_bytes() == b"binary"
+
+
+def test_get_power_station_power_report_by_month_success(
+    mocked_inverter: SingleInverter,
+) -> None:
+    goodwe = mocked_inverter
+    report_data = {
+        "record": 1,
+        "list": [
+            {
+                "pw_id": "1",
+                "pw_name": "Test Station",
+                "capacity": 6.0,
+                "address": "123 Fake St",
+                "owner_id": "u1",
+                "owner_name": "Test Owner",
+                "email": "owner@example.com",
+                "month_power": 688.0,
+                "avg_day_power": 22.2,
+                "total_power": 53159.2,
+                "power_list": None,
+            }
+        ],
+    }
+    with requests_mock.Mocker() as http_mock:
+        http_mock.post(
+            goodwe.base_url + "v1/ReportData/GetPowerStationPowerReportByMonth",
+            json={"msg": "success", "data": report_data},
+            status_code=200,
+        )
+        result = goodwe.getPowerStationPowerReportByMonth(date(2024, 1, 1))
+        assert result == report_data
+        assert result["list"][0]["month_power"] == 688.0

--- a/tests/test_pygoodwe.py
+++ b/tests/test_pygoodwe.py
@@ -203,140 +203,18 @@ def test_getDayDetailedReadingsExcel(
     assert True
 
 
-# def test_report(inverter: SingleInverter) -> None:
-#     """manually doing it"""
-#     # Request URL: https://www.semsportal.com/GopsApi/Post?s=v1/ReportData/GetPowerStationPowerReportByMonth
-#     # str: {"api":"v1/ReportData/GetPowerStationPowerReportByMonth",
-#     # "param":{"date":"2021-12-21","pw_areacode":"","org_id":"","page_index":1,"page_size":1,"is_report":2}}
-
-#     payload = {
-#         "str" :  json.dumps({
-#            "api" : "v1/ReportData/GetPowerStationPowerReportByMonth",
-#             "param" : {
-#                 "date" : (date.today()-timedelta(days=1)).strftime("%Y-%m-%d"),
-#                 "pw_areacode" : "",
-#                 "org_id" : "",
-#                 "page_index" : 1,
-#                 "page_size" : 8,
-#                 "is_report" : 1,
-#             },
-#         })
-#     }
-#     headers = dict(inverter.headers)
-#     headers["Referer"] = "https://www.semsportal.com/Statement/PowerDataByMonth"
-#     headers["X-Requested-With"] = "XMLHttpRequest"
-
-#     inverter.do_login()
-#     # logging.error(json.dumps(inverter.headers))
-#     url = "https://www.semsportal.com/GopsApi/Post?s=v1/ReportData/GetPowerStationPowerReportByMonth"
-#     response = inverter.session.post(url=url,
-#                                      data=payload,
-#                                      headers=headers,
-#                                      cookies=inverter.session.cookies,
-#                                      )
-#     response.raise_for_status()
-
-#     try:
-#         responsedata = response.json()
-#     except JSONDecodeError as error_message:
-#         logging.error("JSON Decode error: %s\n%s", error_message, response.content)
-#         pytest.fail()
-#     if responsedata.get("hasError"):
-#         pytest.fail()
-#     if responsedata.get('msg').lower() not in ("success", "successful"):
-#         logging.error("Failed pulling the download ID!")
-#         logging.error(response.request.url)
-#         logging.error("Req headers: %s", json.dumps(response.request.headers, default=str))
-#         logging.error(responsedata)
-#         logging.error(inverter.session.cookies)
-
-#         pytest.fail()
-
-
-#     download_id = responsedata.get("data",{}).get("qry_id", {})
-#     print(f"Download ID: {download_id}")
-
-#     # Response
-#     # {
-#     #   "hasError": false,
-#     #   "code": 0,
-#     #   "msg": "Successful",
-#     #   "data": {
-#     #     "record": 1,
-#     #     "list": [
-#     #       {
-#     #         "pw_id": "<station_id>",
-#     #         "pw_name": "<name>",
-#     #         "capacity": 1.0,
-#     #         "address": "<address>",
-#     #         "owner_id": "<uuid>",
-#     #         "owner_name": null,
-#     #         "email": "user@example.com",
-#     #         "month_power": 663.3,
-#     #         "avg_day_power": 31.6,
-#     #         "total_power": 1.2,
-#     #         "power_list": null
-#     #       }
-#     #     ],
-#     #     "qry_id": "<download_id>"
-#     #   },
-#     #   "components": {
-#     #     "para": null,
-#     #     "langVer": 125,
-#     #     "timeSpan": 0,
-#     #     "api": "http://localhost:82/api/v1/ReportData/GetPowerStationPowerReportByMonth",
-#     #     "msgSocketAdr": ""
-#     #   }
-#     # }
-
-#     response = requests.post(url="https://www.semsportal.com/GopsApi/Post",
-#         params={
-#             "s": "v1/ReportData/GetStationPowerDataFilePath",
-#             },
-#         data = {
-#             "api" : "v1/ReportData/GetStationPowerDataFilePath",
-#             "param" : {
-#                 "id" : download_id,
-#             }
-#         },
-#     )
-#     response.raise_for_status()
-
-#     try:
-#         responsedata = response.json()
-#     except JSONDecodeError as error_message:
-#         logging.error("JSON Decode error: %s\n%s", error_message, response.content)
-#         pytest.fail()
-#     if responsedata.get("hasError"):
-#         pytest.fail()
-#     if responsedata.get('msg').lower() not in ("success", "successful"):
-#         logging.error("Failed!")
-#         pytest.fail()
-
-#     download_url = responsedata.get("data",{}).get("file_path", False)
-#     if not download_url:
-#         logging.error("Failed to get download URL from data:\n%s", responsedata.content)
-#         # return False
-#         pytest.fail()
-
-#     # Request URL: https://www.semsportal.com/GopsApi/Post?s=v1/ReportData/GetStationPowerDataFilePath
-#     # str: {"api":"v1/ReportData/GetStationPowerDataFilePath",
-#     #       "param":{"id":"<download_id>"}
-#     # }
-
-#     # Response
-#     # {
-#     #     "hasError": false,
-#     #     "code": 0,
-#     #     "msg": "Successful",
-#     #     "data": {
-#     #         "file_path": "<download_url>"
-#     #     },
-#     #     "components": {
-#     #         "para": null,
-#     #         "langVer": 125,
-#     #         "timeSpan": 0,
-#     #         "api": "http://localhost:82/api/v1/ReportData/GetStationPowerDataFilePath",
-#     #         "msgSocketAdr": ""
-#     #     }
-#     # }
+def test_getPowerStationPowerReportByMonth(
+    inverter: SingleInverter,
+) -> None:
+    """monthly power report endpoint returns data for a known month"""
+    if not os.environ.get("GOODWE_USE_CONFIG", False):
+        pytest.skip()
+    result = inverter.getPowerStationPowerReportByMonth(date(2024, 1, 1))
+    assert result is not None
+    assert "list" in result
+    assert len(result["list"]) >= 1
+    entry = result["list"][0]
+    assert entry["pw_id"] == inverter.system_id
+    assert isinstance(entry.get("month_power"), (int, float))
+    assert isinstance(entry.get("avg_day_power"), (int, float))
+    assert isinstance(entry.get("total_power"), (int, float))


### PR DESCRIPTION
## Summary

Replaces the commented-out `test_report` stub with a working implementation of the monthly power report endpoint (`v1/ReportData/GetPowerStationPowerReportByMonth`).

The original stub assumed a two-step export→download-URL flow like the daily Excel endpoint, but the real API returns report data inline as JSON. The new method follows the same `self.call()` pattern used elsewhere in the codebase.

## Changes

- **`pygoodwe/__init__.py`** — Added `getPowerStationPowerReportByMonth(report_date, page_index=1, page_size=8)` returning `Optional[Dict[str, Any]]` with `record`, `list`, `month_power`, `avg_day_power`, `total_power`.
- **`tests/test_pygoodwe.py`** — Replaced 137-line commented-out stub with a live test validating real API data.
- **`tests/test_mocked.py`** — Added mocked test covering the method without network calls.
- **`example_monthly_report_jsonl.py`** — Example script that dumps the last 6 months as JSONL.

## Test Results

All 23 tests pass (14 mocked + 9 live with `GOODWE_USE_CONFIG=1`).